### PR TITLE
feat: support multi-byte characters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/brianhuster/nvcat
 
 go 1.24.1
 
+require github.com/neovim/go-client v1.2.1
+
 require (
-	github.com/neovim/go-client v1.2.1
+	github.com/clipperhouse/uax29 v1.14.3 // indirect
+	golang.org/x/text v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/clipperhouse/uax29 v1.14.3 h1:pJ0hZWycgsBrJ8SSsvPCrlMTpW8C+fdcA/0mehFDCU0=
+github.com/clipperhouse/uax29 v1.14.3/go.mod h1:paNABhygWmmjkg0ROxKQoenJAX4dM9AS8biVkXmAK0c=
 github.com/neovim/go-client v1.2.1 h1:kl3PgYgbnBfvaIoGYi3ojyXH0ouY6dJY/rYUCssZKqI=
 github.com/neovim/go-client v1.2.1/go.mod h1:EeqCP3z1vJd70JTaH/KXz9RMZ/nIgEFveX83hYnh/7c=
+golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
+golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"strconv"
 	"bytes"
-	"github.com/clipperhouse/uax29/words"
+	"github.com/clipperhouse/uax29/graphemes"
 )
 
 const (
@@ -182,7 +182,7 @@ func getAnsiFromHl(hl map[string]any) (string, error) {
 
 func printHighlightedLine(vim *nvim.Nvim, lineNum int, line string, opts formatOpts) (string, error) {
 	var currentAnsi string
-	segments := words.NewSegmenter([]byte(line))
+	segments := graphemes.NewSegmenter([]byte(line))
 	col := 0
 	for segments.Next() {
 		var hl map[string]any

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"strconv"
 	"bytes"
+	"github.com/clipperhouse/uax29/words"
 )
 
 const (
@@ -181,11 +182,15 @@ func getAnsiFromHl(hl map[string]any) (string, error) {
 
 func printHighlightedLine(vim *nvim.Nvim, lineNum int, line string, opts formatOpts) (string, error) {
 	var currentAnsi string
-
-	for col := range len(line) {
+	segments := words.NewSegmenter([]byte(line))
+	col := 0
+	for segments.Next() {
 		var hl map[string]any
-		if line[col] == '\t' {
+		token := segments.Text()
+		token_len := len(token)
+		if token_len == 1 && token[0] == '\t' {
 			fmt.Fprint(os.Stdout, opts.tab)
+			col += token_len
 			continue
 		}
 		err := vim.ExecLua("return NvcatGetHl(...)", &hl, lineNum, col)
@@ -194,7 +199,8 @@ func printHighlightedLine(vim *nvim.Nvim, lineNum int, line string, opts formatO
 				fmt.Fprint(os.Stderr, AnsiReset)
 				currentAnsi = ""
 			}
-			fmt.Fprint(os.Stdout, string(line[col]))
+			fmt.Fprint(os.Stdout, token)
+			col += token_len
 			continue
 		}
 
@@ -204,7 +210,8 @@ func printHighlightedLine(vim *nvim.Nvim, lineNum int, line string, opts formatO
 				fmt.Fprint(os.Stderr, AnsiReset)
 				currentAnsi = ""
 			}
-			fmt.Fprint(os.Stdout, string(line[col]))
+			fmt.Fprint(os.Stdout, token)
+			col += token_len
 			continue
 		}
 
@@ -217,7 +224,8 @@ func printHighlightedLine(vim *nvim.Nvim, lineNum int, line string, opts formatO
 			currentAnsi = ansi
 		}
 
-		fmt.Fprint(os.Stdout, string(line[col]))
+		fmt.Fprint(os.Stdout, token)
+		col += token_len
 	}
 
 	// Reset color at the end of the line


### PR DESCRIPTION
Handle multi-byte characters.
```bash
git clone https://github.com/neovim/neovim
./nvcat neovim/test/old/testdir/test_cjk_linebreak.vim
./nvcat neovim/test/unit/mbyte_spec.lua
```

Also a bit faster for large file:
```bash
$ hyperfine -w 5 './nvcat /usr/include/libgccjit++.h'
  Time (mean ± σ):      5.176 s ±  0.127 s    [User: 4.400 s, System: 1.330 s]
  Range (min … max):    5.061 s …  5.504 s    10 runs
 
$ hyperfine -w 5 './nvcat /usr/include/libgccjit++.h'
  Time (mean ± σ):     14.499 s ±  0.210 s    [User: 12.209 s, System: 3.953 s]
  Range (min … max):   14.196 s … 14.769 s    10 runs
```